### PR TITLE
Change Github link in footer to correct account

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -36,7 +36,7 @@
 
         <div class="col-sm-3 col-xs-6 footer-item">
           <h3>Follow us</h3>
-          <p><a href="https://twitter.com/openupsa" target="_blank"><i class="fa fa-twitter fa-2x smicon" aria-hidden="true"></i></a><a href="https://www.facebook.com/openupsa" target="_blank"><i class="fa fa-facebook fa-2x smicon" aria-hidden="true"></i></a><a href="https://github.com/Code4SA" target="_blank"><i class="fa fa-github-alt fa-2x smicon" aria-hidden="true"></i></a><a href="https://www.linkedin.com/company/code-for-south-africa" target="_blank"><i class="fa fa-linkedin-square fa-2x smicon" aria-hidden="true"></i></a></p>
+          <p><a href="https://twitter.com/openupsa" target="_blank"><i class="fa fa-twitter fa-2x smicon" aria-hidden="true"></i></a><a href="https://www.facebook.com/openupsa" target="_blank"><i class="fa fa-facebook fa-2x smicon" aria-hidden="true"></i></a><a href="https://github.com/openupsa" target="_blank"><i class="fa fa-github-alt fa-2x smicon" aria-hidden="true"></i></a><a href="https://www.linkedin.com/company/code-for-south-africa" target="_blank"><i class="fa fa-linkedin-square fa-2x smicon" aria-hidden="true"></i></a></p>
         </div>
 
       </div>


### PR DESCRIPTION
Current Github link in footer still points to the old https://github.com/code4sa account.