### PR TITLE
Fixed email subscribe weirdness on data training page

### DIFF
--- a/_includes/data_newsletter-signup.html
+++ b/_includes/data_newsletter-signup.html
@@ -1,0 +1,18 @@
+<!-- Begin MailChimp Signup Form -->
+<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
+<style type="text/css">
+  #mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; width:100%;}
+</style>
+<div id="mc_embed_signup">
+  <form action="https://openup.us17.list-manage.com/subscribe/post?u=f4e136de8ccb70cedf7a034ef&amp;id=1f37c66157" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+    <div id="mc_embed_signup_scroll">
+      <!--<label for="mce-EMAIL">Subscribe to our mailing list</label>-->
+      <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
+      <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+      <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_f4e136de8ccb70cedf7a034ef_1f37c66157" tabindex="-1" value=""></div>
+      <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+      <p>Alternatively, read our <a href="#faq">FAQ</a> or email us at <a href="mailto:training@openup.org.za">training@openup.org.za</a></p>
+    </div>
+  </form>
+</div>
+<!--End mc_embed_signup-->

--- a/_includes/newsletter-signup.html
+++ b/_includes/newsletter-signup.html
@@ -1,5 +1,5 @@
 <!-- Begin MailChimp Signup Form -->
-<div id="mc_embed_signup">
+<div id="mc_embed_signup_footer">
   <form action="//code4sa.us8.list-manage.com/subscribe/post?u=11977a67604b965526b63ee6e&amp;id=0852ce7e74" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
     <div id="mc_embed_signup_scroll">
 

--- a/css/main.scss
+++ b/css/main.scss
@@ -425,7 +425,7 @@ body {
           background-color: $green-darker;
         }
       }
-      #mc_embed_signup form {
+      #mc_embed_signup_footer form {
         margin-top: 10px;
       }
     }
@@ -546,7 +546,7 @@ body {
     }
   }
 
-  #mc_embed_signup {
+  #mc_embed_signup_footer {
     .lname,
     .fname {
       display: none;
@@ -1276,7 +1276,7 @@ footer {
   a {
     color: #999;
   }
-  #mc_embed_signup {
+  #mc_embed_signup_footer {
     .lname,
     .fname {
       display: none;
@@ -2257,7 +2257,7 @@ footer {
 }
 
 /* MailChimp Form */
-#mc_embed_signup {
+#mc_embed_signup_footer {
   form {
     display:block;
     position:relative;

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ layout: base
         <div class="col-md-4 signup">
           <h3>Subscribe to our newsletter</h3>
           <!-- Begin MailChimp Signup Form -->
-          <div id="mc_embed_signup">
+          <div id="mc_embed_signup_footer">
             <form action="//code4sa.us8.list-manage.com/subscribe/post?u=11977a67604b965526b63ee6e&amp;id=0852ce7e74" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
               <div id="mc_embed_signup_scroll">
 
@@ -277,7 +277,6 @@ layout: base
       <div class="row">
         <div class="col-md-6">
           <h3><b>Our weekly newsletter</b> on data, journalism, civic tech and everything in between. Every Friday, to get your weekend started.</h3>
-
           {% include newsletter-signup.html %}
         </div>
         <div class="col-md-6">

--- a/trainup/index.html
+++ b/trainup/index.html
@@ -206,24 +206,7 @@ short: Data-driven storytelling training for people working in the public and pr
       <p class="trainup-section-annotation"><i class="fa fa-tty" aria-hidden="true"></i>&nbsp; Get in touch</p>
       <h1 class="title">Stay up to date</h1>
       <p>Join our mailing list stay up to date with our upcoming training events, publications and more.</p>
-      <!-- Begin MailChimp Signup Form -->
-      <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-      <style type="text/css">
-      #mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; width:100%;}
-      </style>
-      <div id="mc_embed_signup">
-        <form action="https://openup.us17.list-manage.com/subscribe/post?u=f4e136de8ccb70cedf7a034ef&amp;id=1f37c66157" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-          <div id="mc_embed_signup_scroll">
-            <!--<label for="mce-EMAIL">Subscribe to our mailing list</label>-->
-            <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-            <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-            <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_f4e136de8ccb70cedf7a034ef_1f37c66157" tabindex="-1" value=""></div>
-            <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-            <p>Alternatively, read our <a href="#faq">FAQ</a> or email us at <a href="mailto:training@openup.org.za">training@openup.org.za</a></p>
-          </div>
-        </form>
-      </div>
-<!--End mc_embed_signup-->
+      {% include data_newsletter-signup.html %}
     </div>
   </section>
 
@@ -515,24 +498,7 @@ short: Data-driven storytelling training for people working in the public and pr
       <p class="trainup-section-annotation"><i class="fa fa-tty" aria-hidden="true"></i>&nbsp; Get in touch</p>
       <h1 class="title">Stay up to date</h1>
       <p>Join our mailing list stay up to date with our upcoming training events, publications and more.</p>
-      <!-- Begin MailChimp Signup Form -->
-      <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-      <style type="text/css">
-      #mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; width:100%;}
-      </style>
-      <div id="mc_embed_signup">
-        <form action="https://openup.us17.list-manage.com/subscribe/post?u=f4e136de8ccb70cedf7a034ef&amp;id=1f37c66157" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-          <div id="mc_embed_signup_scroll">
-            <!--<label for="mce-EMAIL">Subscribe to our mailing list</label>-->
-            <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
-            <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-            <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_f4e136de8ccb70cedf7a034ef_1f37c66157" tabindex="-1" value=""></div>
-            <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-            <p>Alternatively, read our <a href="#faq">FAQ</a> or email us at <a href="mailto:training@openup.org.za">training@openup.org.za</a></p>
-          </div>
-        </form>
-      </div>
-<!--End mc_embed_signup-->
+      {% include data_newsletter-signup.html %}
     </div>
   </section>
 </div>


### PR DESCRIPTION
The email subscribe layout was breaking because of another stylesheet that is pulled in to style the other two email signup forms on the data training page. I have updated the id attribute for the footer style email signup forms.

![screen shot 2018-09-11 at 21 14 09](https://user-images.githubusercontent.com/13785692/45382135-a7bce180-b607-11e8-9758-ec9d89076b38.png)
